### PR TITLE
Gerenciador de Arquivos LXQt.

### DIFF
--- a/biglinux-apps-rename/usr/share/libalpm/scripts/biglinux-apps-rename2
+++ b/biglinux-apps-rename/usr/share/libalpm/scripts/biglinux-apps-rename2
@@ -19,6 +19,12 @@ if [ "$(grep NotShowIn /usr/share/applications/pcmanfm-qt-desktop-pref.desktop)"
     echo 'NotShowIn=KDE' >> /usr/share/applications/pcmanfm-qt.desktop
 fi
 
+# pcmanfm-qt-desktop
+#Renomeia ou inclui a liha do Name[pt_BR]
+if [ "$(grep 'Name[pt_BR]' /usr/share/applications/pcmanfm-qt.desktop)" = "" ] && [ -e "/usr/share/applications/pcmanfm-qt.desktop" ]; then
+    echo 'Name[pt_BR]=Gerenciador de Arquivos' >> /usr/share/applications/pcmanfm-qt.desktop
+fi
+
 # kdenlive
 sed -i 's|Exec=kdenlive|Exec=QT_QUICK_BACKEND="" kdenlive|g' /usr/share/applications/org.kde.kdenlive.desktop
 


### PR DESCRIPTION
Adicionada a linha que modifica o nome do Gerenciador de Arquivos Pcmanfm  para somente Gerenciador de Arquivos.

Para compatibilizar com os menus do BigLinux.